### PR TITLE
fix: use the --chdir option for tflint (>= v0.47)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ validate:
 lint:
 	@echo "🔍 Running tflint..."
 	@tflint --init >/dev/null 2>&1 || true
-	@tflint --recursive --format compact terraform/
+	@tflint --recursive --format compact --chdir terraform/
 	@echo "✅ Linting complete"
 
 # Run tfsec security scan


### PR DESCRIPTION
## Description

## Type of Change

- [x] Bug fix

  ```bash
  make lint
  🔍 Running tflint...
  Failed to parse CLI options; expected argument for flag `--chdir', but got option `--format'
  make: *** [lint] Error 1
  ```

## Checklist

### Code Quality

- [x] Code follows the repository's style guidelines

### Testing

- [x] Test and fix locally
